### PR TITLE
Update light.py

### DIFF
--- a/custom_components/elkbledom/light.py
+++ b/custom_components/elkbledom/light.py
@@ -117,7 +117,6 @@ class BLEDOMLight(LightEntity):
             },
             name=self.name,
             connections={(device_registry.CONNECTION_NETWORK_MAC, self._instance.mac)},
-            config_entry_id=self._entry_id,
         )
 
     @property


### PR DESCRIPTION
That function is meant to return a DeviceInfo as defined here https://github.com/home-assistant/core/blob/614f3c6a15713aa762269f7c628d4420987cbd4c/homeassistant/helpers/entity.py#L177 So it was probably working by accident before