### PR TITLE
implemented setting actual brightness

### DIFF
--- a/custom_components/elkbledom/elkbledom.py
+++ b/custom_components/elkbledom/elkbledom.py
@@ -265,9 +265,9 @@ class BLEDOMInstance:
         return self._rgb_color
 
     @property
-    def white_brightness(self):
+    def brightness(self):
         return self._brightness
-
+    
     @property
     def color_temp(self):
         return self._color_temp
@@ -279,6 +279,11 @@ class BLEDOMInstance:
     @retry_bluetooth_connection_error
     async def set_white(self, intensity: int):
         await self._write([0x7e, 0x00, 0x01, int(intensity*100/255), 0x00, 0x00, 0x00, 0x00, 0xef])
+        self._brightness = intensity
+        
+    @retry_bluetooth_connection_error
+    async def set_brightness(self, intensity: int):
+        await self._write([0x7e, 0x04, 0x01, int(intensity*100/255), 0xff, 0x00, 0xff, 0x00, 0xef])
         self._brightness = intensity
 
     @retry_bluetooth_connection_error

--- a/custom_components/elkbledom/light.py
+++ b/custom_components/elkbledom/light.py
@@ -54,13 +54,7 @@ class BLEDOMLight(LightEntity):
 
     @property
     def brightness(self):
-        if self._instance.white_brightness:
-            return self._instance.white_brightness
-
-        if self._instance._rgb_color:
-            return max(self._instance.rgb_color)
-
-        return 250
+        return self._instance.brightness
 
     @property
     def is_on(self) -> Optional[bool]:
@@ -124,11 +118,6 @@ class BLEDOMLight(LightEntity):
         """No polling needed for a demo light."""
         return False
 
-    def _transform_color_brightness(self, color: Tuple[int, int, int], set_brightness: int):
-        rgb = match_max_scale((255,), color)
-        res = tuple(color * set_brightness // 255 for color in rgb)
-        return res
-
     async def async_turn_on(self, **kwargs: Any) -> None:
         LOGGER.debug(f"Params turn on: {kwargs}")
         if not self.is_on:
@@ -138,7 +127,7 @@ class BLEDOMLight(LightEntity):
                 await self._instance.set_color(self._transform_color_brightness((255, 255, 255), 250))
 
         if ATTR_BRIGHTNESS in kwargs and kwargs[ATTR_BRIGHTNESS] != self.brightness and self.rgb_color != None:
-            await self._instance.set_color(self._transform_color_brightness(self.rgb_color, kwargs[ATTR_BRIGHTNESS]))
+            await self._instance.set_brightness(kwargs[ATTR_BRIGHTNESS])
 
         if ATTR_COLOR_TEMP in kwargs:
             self._color_mode = ColorMode.COLOR_TEMP
@@ -148,18 +137,13 @@ class BLEDOMLight(LightEntity):
 
         if ATTR_WHITE in kwargs:
             self._color_mode = ColorMode.WHITE
-            if kwargs[ATTR_WHITE] != self.brightness:
-                self._effect = None
-                await self._instance.set_white(kwargs[ATTR_WHITE])
+            self._effect = None
+            await self._instance.set_white(kwargs[ATTR_WHITE])
 
         if ATTR_RGB_COLOR in kwargs:
             self._color_mode = ColorMode.RGB
             if kwargs[ATTR_RGB_COLOR] != self.rgb_color:
                 color = kwargs[ATTR_RGB_COLOR]
-                if ATTR_BRIGHTNESS in kwargs:
-                    color = self._transform_color_brightness(color, kwargs[ATTR_BRIGHTNESS])
-                else:
-                    color = self._transform_color_brightness(color, self.brightness)
                 self._effect = None
                 await self._instance.set_color(color)
 


### PR DESCRIPTION
This PR Implements setting the actual brightness instead of setting an RGB color

Since actual brightness is set it also changes to brightness of effects playing, brightness of RGB and white at once. It also doesn't stop the effect from playing anymore

I tested this with `StripX` (the new model was mentioned in https://github.com/dave-code-ruiz/elkbledom/issues/11, and its different from `Strip` controller) but I assume it will work in older models as well.