### PR TITLE
Add GitHub Actions workflow for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Which version to bump? (Major.Minor.Patch)'
+        required: true
+        type: choice
+        options:
+          - Patch
+          - Minor
+          - Major
+      title:
+        description: 'Short Release title:'
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read latest GitHub release
+        id: current
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(gh release view --json tagName -q .tagName)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Latest release: $VERSION"
+
+      - name: Calculate new version
+        id: bump
+        run: |
+          CURRENT="${{ steps.current.outputs.version }}"
+          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+          MINOR=$(echo "$CURRENT" | cut -d. -f2)
+          PATCH=$(echo "$CURRENT" | cut -d. -f3)
+
+          case "${{ github.event.inputs.bump }}" in
+            Major) NEW="$((MAJOR + 1)).0.0" ;;
+            Minor) NEW="${MAJOR}.$((MINOR + 1)).0" ;;
+            Patch) NEW="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+          esac
+
+          echo "version=$NEW" >> "$GITHUB_OUTPUT"
+          echo "Bump: $CURRENT → $NEW"
+
+      - name: Update manifest.json version
+        run: |
+          perl -0pi -e 's/^(\s*"version"\s*:\s*")[^"]+(".*)$/${1}${ENV{"NEW_VERSION"}}$2/m' custom_components/elkbledom/manifest.json
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add custom_components/elkbledom/manifest.json
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git push
+
+      - name: Create tag
+        run: |
+          git tag "${{ steps.bump.outputs.version }}"
+          git push origin "${{ steps.bump.outputs.version }}"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: "${{ steps.bump.outputs.version }}"
+          name: "ELK-BLEDOM Integration v${{ steps.bump.outputs.version }} - ${{ github.event.inputs.title }}"
+          generate_release_notes: true


### PR DESCRIPTION
This is a manual github action that automatically bumps the version for a new release, including changing the version in manifest.json, which resolves the issue of showing the wrong version in Home Assistant. It also creates an automated changelog and you can input a release title. 